### PR TITLE
Soft Sat Fall 2018 update

### DIFF
--- a/mtts/index.php
+++ b/mtts/index.php
@@ -35,39 +35,11 @@
                     <h1 id="leaders">Leadership</h1>
                     <hr />
                     <div class="row">
-                        <!--Zachary Vander Missen-->
-                        <div class= "col-md-6">
-                            <img src="../images/officers/Zach_Vander_Missen.jpg" alt= "Zachary Vander Missen" class="img-circle" width=250px height=250px />
-                            <h4>Zachary Vander Missen</h4>
-                            <p>Chair<br />Electrical Engineering<br />Second-Year PhD Student</p>
-                        </div>
-                        <!--Michael Anderson-->
-                        <div class= "col-md-6">
-                            <img src="images/michael_anderson.jpg" alt= "Michael Anderson" class="img-circle" width=250px height=250px />
-                            <h4>Michael Anderson</h4>
-                            <p>Vice Chair<br />Industrial Engineering<br />Senior</p>
-                        </div>
-                    </div>
-                    <br />
-                    <div class="row">
                         <!--Alden Fisher-->
                         <div class= "col-md-4">
                             <img src="images/Alden_Fisher.JPG" alt= "Alden Fisher" class="img-circle" width=250px height=250px />
                             <h4>Alden Fisher</h4>
-                            <p>Sponsorship Coordinator<br />Electrical Engineering<br />First-Year Master's Student<p>
-                        </div>
-                        <!--Rayane Chatrieux-->
-                        <div class= "col-md-4">
-                            <img src="" alt= "Rayane Chatrieux" class="img-circle" width=250px height=250px />
-                            <h4>Rayane Chatrieux</h4>
-                            <p>Workshop Coordinator<br />Electrical Engineering<br />Senior</p>
-                        </div>
-                        <!--Alan Han-->
-                        <div class= "col-md-4">
-                            <img src="images/alan_han.jpg" alt= "Alan Han" class="img-circle" width=250px height=250px />
-                            <h4>Alan Han</h4>
-                            <p>Event Coordinator<br />Electrical Engineering<br />Senior</p>
-                        </div>
+                            <p>Chair<br />Electrical Engineering<br />Master's Student</p>
                         </div>
                     </div>
 

--- a/mtts/index.php
+++ b/mtts/index.php
@@ -52,19 +52,22 @@
                     <div class="row">
                         <!--Alden Fisher-->
                         <div class= "col-md-4">
-                            <img src="images/alden_fisher.jpg" alt= "Alden Fisher" class="img-circle" width=250px height=250px />
+                            <img src="images/Alden_Fisher.JPG" alt= "Alden Fisher" class="img-circle" width=250px height=250px />
                             <h4>Alden Fisher</h4>
                             <p>Sponsorship Coordinator<br />Electrical Engineering<br />First-Year Master's Student<p>
+                        </div>
                         <!--Rayane Chatrieux-->
                         <div class= "col-md-4">
                             <img src="" alt= "Rayane Chatrieux" class="img-circle" width=250px height=250px />
                             <h4>Rayane Chatrieux</h4>
                             <p>Workshop Coordinator<br />Electrical Engineering<br />Senior</p>
+                        </div>
                         <!--Alan Han-->
                         <div class= "col-md-4">
                             <img src="images/alan_han.jpg" alt= "Alan Han" class="img-circle" width=250px height=250px />
                             <h4>Alan Han</h4>
                             <p>Event Coordinator<br />Electrical Engineering<br />Senior</p>
+                        </div>
                         </div>
                     </div>
 

--- a/software/android.php
+++ b/software/android.php
@@ -6,7 +6,7 @@
  * Time: 11:05 AM
  */
     $site_title = 'IEEE Software Saturdays';
-    $site_index = '/software';
+    $site_index = '/software/';
     include '../header.php';
 ?>
 <style>

--- a/software/attendee.php
+++ b/software/attendee.php
@@ -1,6 +1,6 @@
 <?php
     $site_title = 'IEEE Software Saturdays';
-    $site_index = '/software';
+    $site_index = '/software/';
     include '../header.php';
 ?>
 <style>

--- a/software/index.php
+++ b/software/index.php
@@ -35,13 +35,15 @@
             </div>
             <hr>
 
+            <h5 class="text-center bg-success">Spring Info Sessions are in <b>ME 1130</b> from <b>11:00 am to 12:30 pm</b> on <b>September 1st & 8th</b></h5>
+
             <p class="text-justify">Software Saturdays is the brand new event fostering the learning of coding and languages, with an aim to give the Attendees a more rounded learning experience.</p>
             <p class="text-justify">The plan is to introduce projects and concepts that are useful in the world of Software Development. Regardless of what major our Attendees are pursuing, we aim to teach skills that will be usefull no matter what job or hobbies they pursue in their future.</p>
             <p class="text-justify">This semester's plan is to do a beginner's Web Development track showing the basics of databases, servers, web page is hosting, and how information flows between them. We'll be using SQLite for the database, ExpressJS for the server (a NodeJS library), and a straightforward HTML, CSS, and JavaScript web page, with helpful Frameworks like jQuery and Bootstrap to minimize code (and work).</p>
             <p class="text-justify">The track is comprised of 5 semi bi-weekly sessions, 2-3 hours long with refreshments and breaks included, for learning the concepts and tools. There will be two 4 hour Project Day sessions afterwards, for Mentors to aid Attendees with the final project. Each Thursday following a session there will be afternoon review hours for questions, general help, and review as well.</p>
             <p class="text-justify">Also, look out for next semester when we take a look into the basics of Android App Development. The curriculum is currently under development, so we'll post more details closer to the Spring semester.</p>
-            <p class="text-justify">For further questions, feel free to email <b>software-saturdays@purdueieee.org</b> for more information.
-            </p>
+            <p class="text-justify">For further questions, feel free to email <b>software-saturdays@purdueieee.org</b> for more information.</p>
+
         </div>
     </div>
 </div>

--- a/software/index.php
+++ b/software/index.php
@@ -1,6 +1,6 @@
 <?php
     $site_title = 'IEEE Software Saturdays';
-    $site_index = '/software';
+    $site_index = '/software/';
     include '../header.php';
 ?>
 <style>
@@ -12,53 +12,34 @@
 <div class="well card-1">
     <div class="row">
         <!-- Content Column -->
-        <div class="col-md-8 text-dark col-md-offset-2">
+        <div class="col-xs-8 text-dark col-xs-offset-2">
             <h2 class="text-center">Software Saturdays</h2>
             <h5 class="text-center">Email us at: <b>software-saturdays@purdueieee.org</b></h5>
-                <!-- Selection Row -->
-                <div class="col-md-12">
+            <!-- Selection Row -->
+            <div class="row">
+                <div class="col-xs-12">
                     <div class="list-group row">
                       <h4>
-                          <a href="attendee.php" class="text-center list-group-item list-group-item-info col-xs-3 col-xs-offset-1">Join as an Attendee</a>
-                          <a href="mentor.php" class="text-center list-group-item list-group-item-info col-xs-3">Join as a Mentor</a>
-                          <a href="android.php" class="text-center list-group-item list-group-item-info col-xs-5">Join as an Android Assistant</a>
+                          <a href="attendee.php" class="text-center list-group-item list-group-item-info col-xs-4 col-xs-offset-2">Join as an Attendee</a>
+                          <a href="mentor.php" class="text-center list-group-item list-group-item-info col-xs-4">Join as a Mentor</a>
+                          <a href="android.php" class="text-center list-group-item list-group-item-info col-xs-6 col-xs-offset-3">Join as an Android Assistant</a>
                       </h4>
                     </div>
                 </div>
-            <hr>
-            <img src="/software/images/tcoffeecode.jpg" alt="Software Saturdays Image" style="width:100%" style="float:left" style="display:block">
+            </div>
+
+            <div class="row">
+                <div class="col-xs-6 col-xs-offset-3">
+                    <img src="./images/tcoffeecode.jpg" alt="Software Saturdays Image" style="width:100%" style="float:left" style="display:block">
+                </div>
+            </div>
             <hr>
 
-            <p class="text-justify">
-                Software Saturdays is the brand new event that's the offspring of Code Café, which has been very popular
-                in the past (and we hope will continue to be). Software Saturdays would like to expand on that idea,
-                fostering the learning of coding and languages, but with a twist. Namely, we want to give the students a
-                more rounded learning experience.
-            </p>
-            <p class="text-justify">
-                This required an expansion on the idea of Code Café. Rather than one Saturday, the track is comprised of
-                5 to 6 Saturdays. The first 4 to 5 sessions will be 3 hours long, and for learning the parts that will
-                be necessary for the project. The last day will be the project day, and the students will have 6 hours
-                to work on the project and tie all those pieces together. The sessions will be held bi-weekly to allow
-                the students to work on their components in between the sessions, and each off week there will be office
-                hours held in case students come across questions as well.
-            </p>
-            <p class="text-justify">
-                The plan is to introduce projects and concepts that are useful in the world of software development. The
-                projects that will be pursued during each semester will be picked based on what would be useful in
-                engineering contexts, but that doesn't mean they're not useful beyond the bounds of engineering.
-                Regardless of what major our students are pursuing, we aim to teach them a skill that will be usefull no
-                matter what job or hobbies they pursue in their future.
-            </p>
-            <p class="text-justify">
-                This semester's plan is to do a beginner's web development track, showing the basics of how a webpage is
-                hosted by a server, and how information typically flows between the page, the server, and a database.
-                We'll be using MySQL Workbench for the database, the Nodejs module Express for the server (and its mysql
-                module to talk to the database), and a straightforward HTML, CSS, and JavaScript/jQuery webpage.
-            </p>
-            <p class="text-justify">
-            For further questions or interest, especially in attending or mentoring and teaching, feel free to email
-            <b>software-saturdays@purdueieee.org</b> for more information.
+            <p class="text-justify">Software Saturdays is the brand new event fostering the learning of coding and languages, with an aim to give the Attendees a more rounded learning experience.</p>
+            <p class="text-justify">The plan is to introduce projects and concepts that are useful in the world of Software Development. Regardless of what major our Attendees are pursuing, we aim to teach skills that will be usefull no matter what job or hobbies they pursue in their future.</p>
+            <p class="text-justify">This semester's plan is to do a beginner's Web Development track showing the basics of databases, servers, web page is hosting, and how information flows between them. We'll be using SQLite for the database, ExpressJS for the server (a NodeJS library), and a straightforward HTML, CSS, and JavaScript web page, with helpful Frameworks like jQuery and Bootstrap to minimize code (and work).</p>
+            <p class="text-justify">The track is comprised of 5 semi bi-weekly sessions, 2-3 hours long with refreshments and breaks included, for learning the concepts and tools. There will be two 4 hour Project Day sessions afterwards, for Mentors to aid Attendees with the final project. Each Thursday following a session there will be afternoon review hours for questions, general help, and review as well.</p>
+            <p class="text-justify">For further questions, feel free to email <b>software-saturdays@purdueieee.org</b> for more information.
             </p>
         </div>
     </div>

--- a/software/index.php
+++ b/software/index.php
@@ -39,6 +39,7 @@
             <p class="text-justify">The plan is to introduce projects and concepts that are useful in the world of Software Development. Regardless of what major our Attendees are pursuing, we aim to teach skills that will be usefull no matter what job or hobbies they pursue in their future.</p>
             <p class="text-justify">This semester's plan is to do a beginner's Web Development track showing the basics of databases, servers, web page is hosting, and how information flows between them. We'll be using SQLite for the database, ExpressJS for the server (a NodeJS library), and a straightforward HTML, CSS, and JavaScript web page, with helpful Frameworks like jQuery and Bootstrap to minimize code (and work).</p>
             <p class="text-justify">The track is comprised of 5 semi bi-weekly sessions, 2-3 hours long with refreshments and breaks included, for learning the concepts and tools. There will be two 4 hour Project Day sessions afterwards, for Mentors to aid Attendees with the final project. Each Thursday following a session there will be afternoon review hours for questions, general help, and review as well.</p>
+            <p class="text-justify">Also, look out for next semester when we take a look into the basics of Android App Development. The curriculum is currently under development, so we'll post more details closer to the Spring semester.</p>
             <p class="text-justify">For further questions, feel free to email <b>software-saturdays@purdueieee.org</b> for more information.
             </p>
         </div>

--- a/software/mentor.php
+++ b/software/mentor.php
@@ -1,6 +1,6 @@
 <?php
     $site_title = 'IEEE Software Saturdays';
-    $site_index = '/software';
+    $site_index = '/software/';
     include '../header.php';
 ?>
 <style>

--- a/software/staff.php
+++ b/software/staff.php
@@ -3,24 +3,17 @@
         <h1 id="leaders">Leadership</h1>
         <hr/>
         <div class="row">
-            <!--Gavin Shanley-->
-            <div class="col-md-4">
-                <img src="images/Gavin_Shanley.jpg" alt="Gavin Shanley" class="img-circle" width=200px height=200px/>
-                <h4>Gavin Shanley</h4>
-                <p>Vice Chair<br/><br/></p>
-            </div>
             <!--Ian Sibley-->
-            <div class="col-md-4">
-                <img src="images/Ian_Sibley.jpg" alt="Ian Sibley" class="img-circle" width=200px height=200px/>
+            <div class="col-xs-4 col-xs-offset-2">
+                <img src="./images/Ian_Sibley.jpg" alt="Ian Sibley" class="img-circle" width="200px" height="200px/">
                 <h4>Ian Sibley</h4>
-                <p>Chair<br/><br/></p>
+                <p>Chair<br><br></p>
             </div>
-            <!--Rebecca Chow-->
-            <div class="col-md-4">
-                <img src="images/Rebecca_Chow.jpg" alt="Rebecca Chow" class="img-circle" width=200px height=200px/>
-                <h4>Rebecca Chow</h4>
-                <p>Administration<br/><br/></p>
+            <!--Gavin Shanley-->
+            <div class="col-xs-4">
+                <img src="./images/Gavin_Shanley.jpg" alt="Gavin Shanley" class="img-circle" width="200px" height="200px/">
+                <h4>Gavin Shanley</h4>
+                <p>Vice Chair<br><br></p>
             </div>
-        </div>
     </div>
 </div>


### PR DESCRIPTION
Made our description briefer, to the point a bit more, and updated it for this year's plan (5 sessions + 2 project days).
Took Rebecca's image off since she's overloaded with academic work and won't be joining us this semester.
Had some spacing fun, made our logo a bit smaller so it doesn't dominate (opinions on whether it should go smaller are welcome), I made the button layout a bit different to keep their heights the same to look a little nicer. Stack isn't a bad thing, unless that's just me.

There was an issue with the header, clicking on the link on my locally hosted php version didn't include an ending forward slash, and that broke a few things (stopped at purdueieee.org/ but still served the right page the first time... after that, clicking links broke, and images just didn't work anymore).
Apache might not care? Doesn't seem to be an issue on the main site, but I believe adding the forward slash won't change that already working functionality on the Apache hosted site. Apache might just correct for it where the php hosting client doesn't.

And finally, MTT-S had some issues with their Leadership section. Alden and on didn't have ending `</div>` tags, so they all got cascaded inside of each other. That, and Alden's image tag wasn't correct, it needed a few upper case changes, so I threw them in here just to be nice.

As far as I'm able to test it, I believe this works just fine.