### PR TITLE
Fix circle images

### DIFF
--- a/assets/bootstrap.css
+++ b/assets/bootstrap.css
@@ -338,6 +338,7 @@ img {
 }
 .img-circle {
   border-radius: 50%;
+  object-fit: cover;
 }
 hr {
   margin-top: 20px;


### PR DESCRIPTION
On some of the committee sites, the images in the rounded circles are squished because they are forced to fit into a 1:1 proportion. Because no one takes the time (don't blame you) to crop the photos, this CSS property makes the image zoom in until the full circle is covered without ruining proportions. 

Ex:
![image](https://user-images.githubusercontent.com/5728602/69120173-19878b00-0a56-11ea-8d5a-0e89208d45fa.png)

vs

![image](https://user-images.githubusercontent.com/5728602/69120196-286e3d80-0a56-11ea-96fb-5e164e50fc66.png)
