### PR TITLE
Fixed email hyperlinks

### DIFF
--- a/IR/index.php
+++ b/IR/index.php
@@ -22,7 +22,7 @@
                 </p>
 				<p>
 				    Interested in contacting us?
-					Email <a href="ir@purdueieee.org">ir@purdueieee.org</a> to promote job opportunities, hold a company
+					Email <a href="mailto:ir@purdueieee.org">ir@purdueieee.org</a> to promote job opportunities, hold a company
 					info session, or more.
 				</p>
             </div>

--- a/growth/index.php
+++ b/growth/index.php
@@ -67,7 +67,7 @@ include '../header.php';
 					-->
 					<p>
 					    Have an event for which you need volunteers? Looking to hold outreach?
-						Want to be involved in coordinating? Contact us at <a href="growth@purdueieee.org">growth@purdueieee.org</a>.
+						Want to be involved in coordinating? Contact us at <a href="mailto:growth@purdueieee.org">growth@purdueieee.org</a>.
 					</p>
                     <hr>
                     <div class="col-md-12">

--- a/learning/index.php
+++ b/learning/index.php
@@ -164,7 +164,7 @@ include '../header.php';
             <hr />
             <p>
                 Please contact the current chair, Angelo Guarnero, at
-                <a href="learn@purdueieee.org">learn@purdueieee.org</a> or visit the IEEE office in EE 014 if you
+                <a href="mailto:learn@purdueieee.org">learn@purdueieee.org</a> or visit the IEEE office in EE 014 if you
                 have any questions or concerns.
             </p>
 			<p>


### PR DESCRIPTION
Some hyperlinks were missing the `mailto:` and directed to nowhere.